### PR TITLE
ignore warnings issued by Data::Dumper

### DIFF
--- a/lib/Test2/Tools/TypeTiny.pm
+++ b/lib/Test2/Tools/TypeTiny.pm
@@ -761,6 +761,7 @@ sub _should_sort_into_subtest {
 
 # Helpers
 sub _dd {
+    local $SIG{__WARN__} = sub {};
     my $dd  = Data::Dumper->new([ shift ])->Terse(1)->Indent(0)->Useqq(1)->Deparse(1)->Quotekeys(0)->Sortkeys(1)->Maxdepth(2);
     my $val = $dd->Dump;
     $val =~ s/\s+/ /gs;


### PR DESCRIPTION
Data::Dumper is used to generate textual representations of structures, not for serializing them, so any warnings it issues (e.g. unrecognized types, etc) do not provide actionable information to the user, and serve only to confuse and distract.

In particular, the new perl object type isn't (yet?) handled by Data::Dumper, which results in many warnings being output when structures which contain them are passed to it.